### PR TITLE
⛳️macOS fix

### DIFF
--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -37,7 +37,14 @@
 
 #include <array>
 #include <algorithm>
+
 #include <iostream>
+
+#ifdef __APPLE__
+#include <numeric>
+#include <math.h>
+#endif
+
 
 template<typename T, int M, int N, int O>
 using Array3D = std::array<std::array<std::array<T,O>,N>,M>;


### PR DESCRIPTION
fixes these 2x problems.

/Users/jpope/Documents/gitWorkspace/ext3DLBP/examples/convert_3d_texture_cpp/../../include/utils.hpp:56:19: error: no member named 'accumulate' in namespace 'std'

include/utils.hpp:66:12: error: call to function 'round' that is neither visible in the template
      definition nor found by argument-dependent lookup
        if(round(x) >= th)